### PR TITLE
🔀 :: (#30) - manage location information to local

### DIFF
--- a/core/data/src/main/java/com/ohnalmwo/data/repository/LocationRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ohnalmwo/data/repository/LocationRepositoryImpl.kt
@@ -25,6 +25,10 @@ class LocationRepositoryImpl @Inject constructor(
         localLocationDataSource.setLocations(location = location)
     }
 
+    override suspend fun updateAllLocations(locations: List<LocationInfo>) {
+        localLocationDataSource.updateAllLocations(locations = locations)
+    }
+
     override suspend fun removeLocations(index: Int) {
         localLocationDataSource.removeLocations(index = index)
     }

--- a/core/datastore/src/main/java/com/ohnalmwo/datastore/datasource/LocationsDataSource.kt
+++ b/core/datastore/src/main/java/com/ohnalmwo/datastore/datasource/LocationsDataSource.kt
@@ -8,6 +8,8 @@ interface LocationsDataSource {
 
     suspend fun setLocations(location: LocationInfo)
 
+    suspend fun updateAllLocations(locations: List<LocationInfo>)
+
     suspend fun removeLocations(index: Int)
 
     suspend fun removeAllLocations()

--- a/core/datastore/src/main/java/com/ohnalmwo/datastore/datasource/LocationsDataSourceImpl.kt
+++ b/core/datastore/src/main/java/com/ohnalmwo/datastore/datasource/LocationsDataSourceImpl.kt
@@ -28,6 +28,15 @@ class LocationsDataSourceImpl @Inject constructor(
         }
     }
 
+    override suspend fun updateAllLocations(locations: List<LocationInfo>) {
+        this.locations.updateData {
+            it.toBuilder()
+                .clearLocation()
+                .addAllLocation(locations.map { it.toData() })
+                .build()
+        }
+    }
+
     override suspend fun removeLocations(index: Int) {
         locations.updateData {
             val builder = it.toBuilder()

--- a/core/domain/src/main/java/com/ohnalmwo/domain/repository/LocationRepository.kt
+++ b/core/domain/src/main/java/com/ohnalmwo/domain/repository/LocationRepository.kt
@@ -11,6 +11,8 @@ interface LocationRepository {
 
     suspend fun setLocations(location: LocationInfo)
 
+    suspend fun updateAllLocations(locations: List<LocationInfo>)
+
     suspend fun removeLocations(index: Int)
 
     suspend fun removeAllLocations()

--- a/core/domain/src/main/java/com/ohnalmwo/domain/usecase/location/RemoveSavedLocationsUseCase.kt
+++ b/core/domain/src/main/java/com/ohnalmwo/domain/usecase/location/RemoveSavedLocationsUseCase.kt
@@ -1,0 +1,13 @@
+package com.ohnalmwo.domain.usecase.location
+
+import com.ohnalmwo.domain.repository.LocationRepository
+import javax.inject.Inject
+
+class RemoveSavedLocationsUseCase @Inject constructor(
+    private val locationRepository: LocationRepository
+) {
+    suspend operator fun invoke(index: Int?) {
+        if (index != null) locationRepository.removeLocations(index = index)
+        else locationRepository.removeAllLocations()
+    }
+}

--- a/core/domain/src/main/java/com/ohnalmwo/domain/usecase/location/UpdateAllSavedLocationsUseCase.kt
+++ b/core/domain/src/main/java/com/ohnalmwo/domain/usecase/location/UpdateAllSavedLocationsUseCase.kt
@@ -1,0 +1,13 @@
+package com.ohnalmwo.domain.usecase.location
+
+import com.ohnalmwo.domain.repository.LocationRepository
+import com.ohnalmwo.model.LocationInfo
+import javax.inject.Inject
+
+class UpdateAllSavedLocationsUseCase @Inject constructor(
+    private val locationRepository: LocationRepository
+) {
+    suspend operator fun invoke(locations: List<LocationInfo>) {
+        locationRepository.updateAllLocations(locations = locations)
+    }
+}

--- a/feature/location/src/main/java/com/ohnalmwo/location/LocationManagementScreen.kt
+++ b/feature/location/src/main/java/com/ohnalmwo/location/LocationManagementScreen.kt
@@ -1,5 +1,6 @@
 package com.ohnalmwo.location
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.gestures.scrollBy
@@ -12,8 +13,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -21,6 +22,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ohnalmwo.design_system.component.button.OndoseeBackButton
 import com.ohnalmwo.design_system.theme.OndoseeTheme.colors
 import com.ohnalmwo.location.component.EditableLocationCard
@@ -29,21 +32,57 @@ import com.ohnalmwo.location.component.LocationText
 import com.ohnalmwo.location.util.dragModifier
 import com.ohnalmwo.location.util.move
 import com.ohnalmwo.location.util.rememberDragAndDropListState
+import com.ohnalmwo.location.viewmodel.LocationScreenReducer.*
+import com.ohnalmwo.location.viewmodel.LocationViewModel
+import com.ohnalmwo.model.LocationInfo
+import com.ohnalmwo.ui.rememberFlowWithLifecycle
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
 @Composable
-fun LocationManagementScreen(
-    navigateToBack: () -> Unit
+fun LocationManagementRoute(
+    navigateToBack: () -> Unit,
+    viewModel: LocationViewModel = hiltViewModel()
 ) {
-    val list = remember { mutableStateListOf(1, 2, 3, 4, 5) }
-    val lazyListState = rememberLazyListState()
-    val dragAndDropListState =
-        rememberDragAndDropListState(lazyListState) { from, to ->
-            if (from != 0 && to != 0) {
-                list.move(from, to)
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val effect = rememberFlowWithLifecycle(viewModel.effect)
+
+    LaunchedEffect(Unit) {
+        viewModel.getSavedLocations()
+    }
+
+    LaunchedEffect(effect) {
+        effect.collect { action ->
+            when (action) {
+                is LocationEffect.NavigateToBack -> navigateToBack()
+                else -> Unit
             }
         }
+    }
+
+    LocationManagementScreen(
+        state = state,
+        onUpdateAllLocations = viewModel::updateAllSavedLocations,
+        onRemoveLocations = viewModel::removeSavedLocations,
+        navigateToBack = { viewModel.sendEffect(LocationEffect.NavigateToBack) }
+    )
+}
+
+@Composable
+fun LocationManagementScreen(
+    state: LocationState,
+    onUpdateAllLocations: (List<LocationInfo>) -> Unit,
+    onRemoveLocations: (Int) -> Unit,
+    navigateToBack: () -> Unit
+) {
+    val newList = state.localLocations.toMutableList()
+    val lazyListState = rememberLazyListState()
+    val dragAndDropListState = rememberDragAndDropListState(lazyListState = lazyListState, key = state.localLocations) { from, to ->
+        if (from != 0 && to != 0) {
+            newList.move(from, to)
+            onUpdateAllLocations(newList)
+        }
+    }
     val coroutineScope = rememberCoroutineScope()
     var overscrollJob by remember { mutableStateOf<Job?>(null) }
 
@@ -94,27 +133,27 @@ fun LocationManagementScreen(
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
                 itemsIndexed(
-                    items = list,
-                    key = { index, data ->
-                        data
+                    items = newList,
+                    key = { index, item ->
+                        item.title
                     }
                 ) { index, item ->
                     if (index == 0) {
                         LocationCard(
-                            location = item.toString(),
-                            significant = index.toString(),
+                            location = item.title,
+                            significant = "비 | 강수확률 90%",
                             isCurrentLocation = true,
                             isExtension = false
                         )
                     } else {
                         EditableLocationCard(
                             modifier = Modifier.dragModifier(index, dragAndDropListState),
-                            location = item.toString(),
-                            significant = index.toString(),
+                            location = item.title,
+                            significant = "비 | 강수확률 $index",
                             isCurrentLocation = true,
                             isExtension = false
                         ) {
-                            list.removeAt(index)
+                            onRemoveLocations(index)
                         }
                     }
                 }

--- a/feature/location/src/main/java/com/ohnalmwo/location/LocationScreen.kt
+++ b/feature/location/src/main/java/com/ohnalmwo/location/LocationScreen.kt
@@ -107,8 +107,10 @@ fun LocationScreen(
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
                 itemsIndexed(
-                    items = state.localLocations.distinct(),
-                    key = { index, item -> item.title }
+                    items = state.localLocations,
+                    key = { index, item ->
+                        item.title
+                    }
                 ) { index, item ->
                     LocationCard(
                         location = item.title,

--- a/feature/location/src/main/java/com/ohnalmwo/location/navigation/LocationNavigation.kt
+++ b/feature/location/src/main/java/com/ohnalmwo/location/navigation/LocationNavigation.kt
@@ -5,7 +5,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.ohnalmwo.location.AddLocationRoute
-import com.ohnalmwo.location.LocationManagementScreen
+import com.ohnalmwo.location.LocationManagementRoute
 import com.ohnalmwo.location.LocationRoute
 import com.ohnalmwo.model.enum.Route
 
@@ -35,7 +35,7 @@ fun NavGraphBuilder.locationManagementScreen(
     navigateToBack: () -> Unit
 ) {
     composable<Route.Location.LocationManagement> {
-        LocationManagementScreen(navigateToBack = navigateToBack)
+        LocationManagementRoute(navigateToBack = navigateToBack)
     }
 }
 

--- a/feature/location/src/main/java/com/ohnalmwo/location/util/DragAndDropListState.kt
+++ b/feature/location/src/main/java/com/ohnalmwo/location/util/DragAndDropListState.kt
@@ -11,11 +11,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
 
 @Composable
-fun rememberDragAndDropListState(
+fun <T> rememberDragAndDropListState(
 	lazyListState: LazyListState,
+	key: List<T> = emptyList(),
 	onMove: (Int, Int) -> Unit
 ): DragAndDropListState {
-	return remember { DragAndDropListState(lazyListState, onMove) }
+	return remember(key) { DragAndDropListState(lazyListState, onMove) }
 }
 
 class DragAndDropListState(

--- a/feature/location/src/main/java/com/ohnalmwo/location/viewmodel/LocationViewModel.kt
+++ b/feature/location/src/main/java/com/ohnalmwo/location/viewmodel/LocationViewModel.kt
@@ -6,7 +6,9 @@ import com.ohnalmwo.common.result.Result
 import com.ohnalmwo.common.result.asResult
 import com.ohnalmwo.domain.usecase.location.GetLocationCoordinateUseCase
 import com.ohnalmwo.domain.usecase.location.GetSavedLocationsUseCase
+import com.ohnalmwo.domain.usecase.location.RemoveSavedLocationsUseCase
 import com.ohnalmwo.domain.usecase.location.SetSavedLocationsUseCase
+import com.ohnalmwo.domain.usecase.location.UpdateAllSavedLocationsUseCase
 import com.ohnalmwo.location.viewmodel.LocationScreenReducer.*
 import com.ohnalmwo.model.LocationInfo
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -18,6 +20,8 @@ class LocationViewModel @Inject constructor(
     private val getLocationCoordinateUseCase: GetLocationCoordinateUseCase,
     private val getSavedLocationsUseCase: GetSavedLocationsUseCase,
     private val setSavedLocationsUseCase: SetSavedLocationsUseCase,
+    private val updateAllSavedLocationsUseCase: UpdateAllSavedLocationsUseCase,
+    private val removeSavedLocationsUseCase: RemoveSavedLocationsUseCase,
 ) : BaseViewModel<LocationState, LocationEvent, LocationEffect>(
     initialState = LocationState.initial(),
     reducer = LocationScreenReducer()
@@ -49,5 +53,13 @@ class LocationViewModel @Inject constructor(
     fun setSavedLocations(location: LocationInfo) = viewModelScope.launch {
         setSavedLocationsUseCase(location = location)
         sendEvent(event = LocationEvent.SetSavedLocations)
+    }
+
+    fun updateAllSavedLocations(locations: List<LocationInfo>) = viewModelScope.launch {
+        updateAllSavedLocationsUseCase(locations = locations)
+    }
+
+    fun removeSavedLocations(index: Int?) = viewModelScope.launch {
+        removeSavedLocationsUseCase(index = index)
     }
 }


### PR DESCRIPTION
## 📌 개요
- 로컬의 위치 정보 관리하기

## 🔀 변경사항
- 로컬에 저장된 위치 전체 변경 기능 추가
- rememberDragAndDropListState에 key 파라미터 추가

## 📸 구현 화면
[Screen_recording_20241127_160310.webm](https://github.com/user-attachments/assets/b770817c-0ac7-497f-b1f8-7da8e37a852d)

